### PR TITLE
Fix issue 3: mime.lookup error

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function expressMd(options) {
 
                     if (err) return next(err);
 
-                    var headers = { 'Content-Type': mime.lookup(ext) };
+                    var headers = { 'Content-Type': mime.getType(ext) };
                     res.writeHead(200, Object.assign({}, defaultHeaders, headers));
                     res.end(buffer);
                 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-md",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Express middleware to serve markdown files as HTML",
   "homepage": "https://github.com/orca-scan/express-md",
   "keywords": [
@@ -25,7 +25,7 @@
     "async": "~0.1.22",
     "js-yaml": "^3.14.0",
     "marked": "^1.1.1",
-    "mime": "^2.4.6"
+    "mime": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^7.4.0",


### PR DESCRIPTION
There's a single use of the 'mime' library, and it's become obsolete.  It should now use 'mime.getType' instead of 'mime.lookup'.