### PR TITLE
Add variable replacement to markdown

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -35,7 +35,7 @@ function render(target, baseDir, serverVariables, callback) {
             data = removeMarkdownVariables(data);
 
             // overwrite markdown var if it exists
-            replacements.markdown = marked(data);
+            replacements.markdown = replaceMarkdownPlaceholders(marked(data), replacements);
 
             if (template) {
                 fs.readFile(template, function (err, data) {
@@ -85,6 +85,24 @@ function removeMarkdownVariables(str) {
 }
 
 /**
+ * Replaces Markdown {{{ key }}} placeholders; differs from
+ * replaceHtmlPlaceholders in that it returns a string, not a buffer.
+ * @param {string} markdown - markdown containing placeholders
+ * @param {object} replacements - key/value pair of variables to place
+ * @returns {String} modified Markdown content
+ */
+function replaceMarkdownPlaceholders(markdown, replacements) {
+
+    replacements = replacements || {};
+
+    Object.keys(replacements).forEach(function(key) {
+        markdown = markdown.replace(new RegExp('\{\{\{\ *' + key + '\ *\}\}\}', 'g'), replacements[key]);
+    });
+
+    return markdown;
+}
+
+/**
  * Replaces HTML {{{ key }}} placeholders
  * @param {string} html - html containing placeholders
  * @param {object} replacements - key/value pair of valiables to place
@@ -98,7 +116,7 @@ function replaceHtmlPlaceholders(html, replacements) {
         html = html.replace(new RegExp('\{\{\{\ *' + key + '\ *\}\}\}', 'g'), replacements[key]);
     });
 
-    return new Buffer(html);
+    return Buffer.from(html);
 }
 
 module.exports = render;


### PR DESCRIPTION
Variable replacement was apparently not happening with markdown content.  I added a new function to do this, rather than using the existing one that returns a buffer, and calling toString() on the buffer.

I also updated `new Buffer()` to `Buffer.from()` as this was causing issues for me on Node 16.